### PR TITLE
Add more-efficient waiting for ambari-agent registration

### DIFF
--- a/playbooks/roles/ambari-server/tasks/main.yml
+++ b/playbooks/roles/ambari-server/tasks/main.yml
@@ -32,6 +32,17 @@
   slurp: src=/tmp/alert_targets
   register: alert_targets
 
+- name: Check if alert_targets already exists
+  uri: url=http://{{ ansible_fqdn }}:8080/api/v1/alert_targets
+       method=GET
+       force_basic_auth=yes
+       user=admin
+       password=admin
+       HEADER_X-Requested-By="ambari"
+       status_code=200,201,202,404
+       return_content=yes
+  register: current_alert_targets
+
 - name: Register the alert_targets with the Ambari server
   uri: url=http://{{ ansible_fqdn }}:8080/api/v1/alert_targets
        method=POST
@@ -41,6 +52,7 @@
        HEADER_X-Requested-By="ambari"
        body='{{ alert_targets.content | b64decode }}'
        status_code=200,201,202
+  when: '"AlertTarget" not in current_alert_targets.content'
 
 - name: Slurp the blueprint
   slurp: src=/tmp/cluster_blueprint

--- a/playbooks/roles/ambari-server/tasks/prerequisites.yml
+++ b/playbooks/roles/ambari-server/tasks/prerequisites.yml
@@ -15,7 +15,9 @@
        user=admin
        password=admin
        HEADER_X-Requested-By="ambari"
-       status_code=200,201,202
+       status_code=200,201,202,404
   with_items: groups['hadoop-cluster']
+  register: result
+  until: "result.status != 404"
   retries: 200
-  delay: 3
+  delay: 5

--- a/playbooks/roles/ambari-server/tasks/prerequisites.yml
+++ b/playbooks/roles/ambari-server/tasks/prerequisites.yml
@@ -8,6 +8,9 @@
 - name: Enable the ambari-server service
   service: name=ambari-server state=restarted enabled=yes
 
+- name: Waiting for ambari-server to start listening on port 8080
+  wait_for: host={{ansible_fqdn}} port=8080
+
 - name: Waiting for ambari-agents to register
   uri: url=http://{{ ansible_fqdn }}:8080/api/v1/hosts/{{ hostvars[item]['ansible_fqdn'] }}
        method=GET

--- a/playbooks/roles/ambari-server/tasks/prerequisites.yml
+++ b/playbooks/roles/ambari-server/tasks/prerequisites.yml
@@ -8,5 +8,14 @@
 - name: Enable the ambari-server service
   service: name=ambari-server state=restarted enabled=yes
 
-- name: Pausing to allow the ambari-agents to register
-  pause: seconds=60
+- name: Waiting for ambari-agents to register
+  uri: url=http://{{ ansible_fqdn }}:8080/api/v1/hosts/{{ hostvars[item]['ansible_fqdn'] }}
+       method=GET
+       force_basic_auth=yes
+       user=admin
+       password=admin
+       HEADER_X-Requested-By="ambari"
+       status_code=200,201,202
+  with_items: groups['hadoop-cluster']
+  retries: 200
+  delay: 3


### PR DESCRIPTION
Checks the API to detect when agent registration has completed instead of a blind 60-second delay.
