### PR TITLE
Disabled host key checking for dedicated bootstrapping; increased fork limit

### DIFF
--- a/bootstrap_dedicated.sh
+++ b/bootstrap_dedicated.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-ansible-playbook -i inventory/static playbooks/bootstrap.yml
+ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -f 20 -i inventory/static playbooks/bootstrap.yml

--- a/hortonworks_dedicated.sh
+++ b/hortonworks_dedicated.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-ansible-playbook -i inventory/static playbooks/hortonworks.yml
+ansible-playbook -f 20 -i inventory/static playbooks/hortonworks.yml


### PR DESCRIPTION
Disabled host key checking for dedicated bootstrapping since we're using password instead of SSH keys.  I also increased the fork limit from the default of 5 to 20 to decrease playbook execution time.
