### PR TITLE
Changed data_disks_devices to reference slave node in Ambari blueprints

### DIFF
--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
@@ -2,7 +2,7 @@
   "configurations" : [
       {
       "hdfs-site" : {
-        "dfs.datanode.data.dir" : "{% if data_disks_devices is defined and data_disks_devices and data_disks_devices|length > 1 %}{% for disk in data_disks_devices %}/disk{{ loop.index }}/hadoop/hdfs/data{% if not loop.last %},{% endif %}{%- endfor %}{% else %}/hadoop/hdfs/data{% endif %}",
+        "dfs.datanode.data.dir" : "{% if hostvars[groups['slave-nodes'][0]]['data_disks_devices'] is defined and hostvars[groups['slave-nodes'][0]]['data_disks_devices'] and hostvars[groups['slave-nodes'][0]]['data_disks_devices']|length > 1 %}{% for disk in hostvars[groups['slave-nodes'][0]]['data_disks_devices'] %}/disk{{ loop.index }}/hadoop/hdfs/data{% if not loop.last %},{% endif %}{%- endfor %}{% else %}/hadoop/hdfs/data{% endif %}",
         "dfs.datanode.failed.volumes.tolerated" : "{{ hdfs.failed_volumes_tolerated }}",
         "dfs.replication" : "{{ hdfs.dfs_replication }}"
       }

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
@@ -2,7 +2,7 @@
   "configurations" : [
       {
       "hdfs-site" : {
-        "dfs.datanode.data.dir" : "{% if data_disks_devices is defined and data_disks_devices and data_disks_devices|length > 1 %}{% for disk in data_disks_devices %}/disk{{ loop.index }}/hadoop/hdfs/data{% if not loop.last %},{% endif %}{%- endfor %}{% else %}/hadoop/hdfs/data{% endif %}",
+        "dfs.datanode.data.dir" : "{% if hostvars[groups['slave-nodes'][0]]['data_disks_devices'] is defined and hostvars[groups['slave-nodes'][0]]['data_disks_devices'] and hostvars[groups['slave-nodes'][0]]['data_disks_devices']|length > 1 %}{% for disk in hostvars[groups['slave-nodes'][0]]['data_disks_devices'] %}/disk{{ loop.index }}/hadoop/hdfs/data{% if not loop.last %},{% endif %}{%- endfor %}{% else %}/hadoop/hdfs/data{% endif %}",
         "dfs.datanode.failed.volumes.tolerated" : "{{ hdfs.failed_volumes_tolerated }}",
         "dfs.replication" : "{{ hdfs.dfs_replication }}"
       }

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
@@ -2,7 +2,7 @@
   "configurations" : [
       {
       "hdfs-site" : {
-        "dfs.datanode.data.dir" : "{% if data_disks_devices is defined and data_disks_devices and data_disks_devices|length > 1 %}{% for disk in data_disks_devices %}/disk{{ loop.index }}/hadoop/hdfs/data{% if not loop.last %},{% endif %}{%- endfor %}{% else %}/hadoop/hdfs/data{% endif %}",
+        "dfs.datanode.data.dir" : "{% if hostvars[groups['slave-nodes'][0]]['data_disks_devices'] is defined and hostvars[groups['slave-nodes'][0]]['data_disks_devices'] and hostvars[groups['slave-nodes'][0]]['data_disks_devices']|length > 1 %}{% for disk in hostvars[groups['slave-nodes'][0]]['data_disks_devices'] %}/disk{{ loop.index }}/hadoop/hdfs/data{% if not loop.last %},{% endif %}{%- endfor %}{% else %}/hadoop/hdfs/data{% endif %}",
         "dfs.datanode.failed.volumes.tolerated" : "{{ hdfs.failed_volumes_tolerated }}",
         "dfs.replication" : "{{ hdfs.dfs_replication }}"
       }


### PR DESCRIPTION
In the multi-node blueprints, I changed references to the data_disks_devices variable to pull from the first slave node rather than the Ambari node.  This fixes a bug where datanodes with multiple disks will be configured with a dfs.datanode.data.dir of just "/hadoop/hdfs/data".
