### PR TITLE
Dynamic bond interface name + removed "ansible_" prefix

### DIFF
--- a/playbooks/group_vars/edge-nodes
+++ b/playbooks/group_vars/edge-nodes
@@ -3,7 +3,7 @@
 ## cloud servers ##
 ###################
 
-cluster_interface: 'ansible_eth1'
+cluster_interface: 'eth1'
 cloud_nodes_count: 0
 cloud_image: 'CentOS 6 (PVHVM)'
 cloud_flavor: 'general1-2'
@@ -16,7 +16,7 @@ data_disks_devices: ['xvde']
 # onmetal #
 ###########
 
-# cluster_interface: 'ansible_bond0.401'
+# cluster_interface: 'bond0.401'
 # cloud_nodes_count: 0
 # cloud_image: 'OnMetal - CentOS 6'
 # cloud_flavor: 'onmetal-io1'
@@ -29,7 +29,7 @@ data_disks_devices: ['xvde']
 # dedicated #
 #############
 
-# cluster_interface: 'ansible_bond0'
+# cluster_interface: 'bond0'
 # bond_interfaces: ['eth4', 'eth6']
 # bond_netmask: '255.255.255.0'
 # data_disks_devices: ['sdb']

--- a/playbooks/group_vars/master-nodes
+++ b/playbooks/group_vars/master-nodes
@@ -3,7 +3,7 @@
 ## cloud servers ##
 ###################
 
-cluster_interface: 'ansible_eth1'
+cluster_interface: 'eth1'
 cloud_nodes_count: 2
 cloud_image: 'CentOS 6 (PVHVM)'
 cloud_flavor: 'general1-4'
@@ -16,7 +16,7 @@ data_disks_devices: []
 # onmetal #
 ###########
 
-# cluster_interface: 'ansible_bond0.401'
+# cluster_interface: 'bond0.401'
 # cloud_nodes_count: 2
 # cloud_image: 'OnMetal - CentOS 6'
 # cloud_flavor: 'onmetal-io1'
@@ -29,7 +29,7 @@ data_disks_devices: []
 # dedicated #
 #############
 
-# cluster_interface: 'ansible_bond0'
+# cluster_interface: 'bond0'
 # bond_interfaces: ['eth4', 'eth6']
 # bond_netmask: '255.255.255.0'
 # data_disks_devices: ['sdb']

--- a/playbooks/group_vars/slave-nodes
+++ b/playbooks/group_vars/slave-nodes
@@ -3,7 +3,7 @@
 ## cloud servers ##
 ###################
 
-cluster_interface: 'ansible_eth1'
+cluster_interface: 'eth1'
 cloud_nodes_count: 3
 cloud_image: 'CentOS 6 (PVHVM)'
 cloud_flavor: 'general1-8'
@@ -16,7 +16,7 @@ data_disks_devices: ['xvde', 'xvdf']
 # onmetal #
 ###########
 
-# cluster_interface: 'ansible_bond0.401'
+# cluster_interface: 'bond0.401'
 # cloud_nodes_count: 3
 # cloud_image: 'OnMetal - CentOS 6'
 # cloud_flavor: 'onmetal-io1'
@@ -29,7 +29,7 @@ data_disks_devices: ['xvde', 'xvdf']
 # dedicated #
 #############
 
-# cluster_interface: 'ansible_bond0'
+# cluster_interface: 'bond0'
 # bond_interfaces: ['eth4', 'eth6']
 # bond_netmask: '255.255.255.0'
 # data_disks_devices: ['sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg']

--- a/playbooks/roles/common/tasks/bonding.yml
+++ b/playbooks/roles/common/tasks/bonding.yml
@@ -1,6 +1,6 @@
 ---
 - name: Write bonding.conf file
-  lineinfile: dest=/etc/modprobe.d/bonding.conf line='alias bond0 bonding' state=present create=yes mode=0664 owner=root group=root
+  lineinfile: dest=/etc/modprobe.d/bonding.conf line='alias {{ cluster_interface }} bonding' state=present create=yes mode=0664 owner=root group=root
   notify: Run depmod
 
 - meta: flush_handlers
@@ -10,13 +10,13 @@
   with_items: bond_interfaces
   notify: Restart networking
 
-- name: Write ifcfg file for bond0 interface
-  template: src=ifcfg-bond0 dest=/etc/sysconfig/network-scripts/
+- name: Write ifcfg file for bond interface
+  template: src=ifcfg-bond dest=/etc/sysconfig/network-scripts/ifcfg-{{ cluster_interface }}
   notify: Restart networking
 
 - meta: flush_handlers
 
-- name: Ping between all hosts on bond0 to verify network connectivity
+- name: Ping between all hosts on bond interface to verify network connectivity
   command: /bin/ping -q -c 5 -i 0.2 -W 1 {{ hostvars[item]['bond_ip'] }}
   when: bond_ip is defined and hostvars[item]['bond_ip'] is defined
   with_items: groups['all']

--- a/playbooks/roles/common/tasks/iptables.yml
+++ b/playbooks/roles/common/tasks/iptables.yml
@@ -2,7 +2,7 @@
 - name: Set iptables between cluster nodes
   lineinfile: dest=/etc/sysconfig/iptables
               insertbefore="^-A INPUT"
-              line="-A INPUT -s {{ hostvars[item][hostvars[item]['cluster_interface']]['ipv4']['address'] }}/32 -j ACCEPT"
+              line="-A INPUT -s {{ hostvars[item][['ansible_', hostvars[node]['cluster_interface']]|join]['ipv4']['address'] }}/32 -j ACCEPT"
               state=present
   with_items: play_hosts
   notify: Restart iptables

--- a/playbooks/roles/common/tasks/iptables.yml
+++ b/playbooks/roles/common/tasks/iptables.yml
@@ -2,7 +2,7 @@
 - name: Set iptables between cluster nodes
   lineinfile: dest=/etc/sysconfig/iptables
               insertbefore="^-A INPUT"
-              line="-A INPUT -s {{ hostvars[item][['ansible_', hostvars[node]['cluster_interface']]|join]['ipv4']['address'] }}/32 -j ACCEPT"
+              line="-A INPUT -s {{ hostvars[item][['ansible_', hostvars[item]['cluster_interface']]|join]['ipv4']['address'] }}/32 -j ACCEPT"
               state=present
   with_items: play_hosts
   notify: Restart iptables

--- a/playbooks/roles/common/templates/hosts.j2
+++ b/playbooks/roles/common/templates/hosts.j2
@@ -1,5 +1,6 @@
 127.0.0.1 localhost.localdomain localhost
 ::1 localhost6.localdomain6 localhost6
 {% for node in groups['hadoop-cluster'] %}
-{{ hostvars[node][hostvars[node]['cluster_interface']]['ipv4']['address'] }} {{ hostvars[node]['ansible_fqdn'] }} {{ hostvars[node]['ansible_hostname'] }}
+{{ hostvars[node][['ansible_', hostvars[node]['cluster_interface']]|join]['ipv4']['address'] }} {{ hostvars[node]['ansible_fqdn'] }} {{ hostvars[node]['ansible_hostname'] }}
+
 {% endfor %}

--- a/playbooks/roles/common/templates/ifcfg-bond
+++ b/playbooks/roles/common/templates/ifcfg-bond
@@ -1,4 +1,4 @@
-DEVICE=bond0
+DEVICE={{ cluster_interface }}
 IPADDR={{ bond_ip }}
 NETMASK={{ bond_netmask }}
 NETWORK=

--- a/playbooks/roles/common/templates/ifcfg-eth
+++ b/playbooks/roles/common/templates/ifcfg-eth
@@ -2,5 +2,5 @@ DEVICE={{ item }}
 ONBOOT=yes
 BOOTPROTO=none
 USERCTL=no
-MASTER=bond0
+MASTER={{ cluster_interface }}
 SLAVE=yes


### PR DESCRIPTION
I removed the ansible_ prefix from the cluster_interface variable and moved it into the code.  I then modified bonding to use the cluster_interface as the bond interface name, allowing us to change it from bond0 to bond1, bond2, etc.
