### PR TITLE
Fix for matching hostname line in ambari-agent config

### DIFF
--- a/playbooks/roles/ambari-agent/tasks/main.yml
+++ b/playbooks/roles/ambari-agent/tasks/main.yml
@@ -35,7 +35,7 @@
 
 - name: Configure the Ambari agent
   lineinfile: dest=/etc/ambari-agent/conf/ambari-agent.ini
-              regexp='^hostname='
+              regexp='^hostname\s*='
               line='hostname={{ hostvars[groups['ambari-node'][0]]['ansible_fqdn'] }}'
               state=present
 


### PR DESCRIPTION
Ran into this when changing hostnames on an existing cluster that had gone through an Ambari upgrade.  The ambari-agent.ini config had "hostname = ..." with spaces around the equals sign, which wasn't matches by the lineinfile.
