### PR TITLE
Minor improvements

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,8 +137,8 @@ Modify the file at `~/ansible-hadoop/playbooks/group_vars/master-nodes` to set m
 | cluster_interface  | Should be set to the network device that the HDP nodes will use to communicate between them. |
 | cloud_nodes_count  | Should be set to the desired number of master-nodes (1, 2 or 3).   |
 | cloud_image        | The OS image to be used. Can be `CentOS 6 (PVHVM)`, `CentOS 7 (PVHVM)` or `Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)`. |
-| cloud_flavor       | [Size flavor](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#list-flavors-with-nova) of the nodes. Minimum `general1-8` for Hadoop nodes. |
-| hadoop_disk        | The disk that will be mounted under `/hadoop`. If the [size flavor](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#list-flavors-with-nova) provides with an ephemeral disk, set this to `xvde`. Remove this variable if `/hadoop` should just be a folder on the root filesystem or if the disk has already been partitioned and mounted. |
+| cloud_flavor       | [Size flavor](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#supported-flavors-for-cloud-servers) of the nodes. Minimum `general1-8` for Hadoop nodes. |
+| hadoop_disk        | The disk that will be mounted under `/hadoop`. If the [size flavor](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#supported-flavors-for-cloud-servers) provides with an ephemeral disk, set this to `xvde`. Remove this variable if `/hadoop` should just be a folder on the root filesystem or if the disk has already been partitioned and mounted. |
 | datanode_disks     | Only used for single-nodes clusters. The disks that will be mounted under `/grid/{0..n}`. Should be set if one or more separate disk devices are used for storing HDFS data. |
 
 For single-node clusters, if Rackspace Cloud Block Storage is to be built for storing HDFS data, set the following options:
@@ -195,8 +195,8 @@ Modify the file at `~/ansible-hadoop/playbooks/group_vars/slave-nodes` to set sl
 | cluster_interface  | Should be set to the network device that the HDP nodes will use to communicate between them. |
 | cloud_nodes_count  | Should be set to the desired number of slave-nodes (0 or more).    |
 | cloud_image        | The OS image to be used. Can be `CentOS 6 (PVHVM)`, `CentOS 7 (PVHVM)` or `Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)`. |
-| cloud_flavor       | [Size flavor](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#list-flavors-with-nova) of the nodes. Minimum `general1-8` for Hadoop nodes. |
-| datanode_disks     | The disks that will be mounted under `/grid/{0..n}`. Should be set if one or more separate disk devices are used for storing HDFS data and remove it if the data should be stored on the root filesystem. Can be set to `['xvde']` or `['xvde', 'xvdf']` if the [size flavor](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#list-flavors-with-nova) provides with an ephemeral disk. Alternatively, you can let the playbook build Cloud Block Storage for this purpose. |
+| cloud_flavor       | [Size flavor](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#supported-flavors-for-cloud-servers) of the nodes. Minimum `general1-8` for Hadoop nodes. |
+| datanode_disks     | The disks that will be mounted under `/grid/{0..n}`. Should be set if one or more separate disk devices are used for storing HDFS data and remove it if the data should be stored on the root filesystem. Can be set to `['xvde']` or `['xvde', 'xvdf']` if the [size flavor](https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#supported-flavors-for-cloud-servers) provides with an ephemeral disk. Alternatively, you can let the playbook build Cloud Block Storage for this purpose. |
 
 If Rackspace Cloud Block Storage is to be built for storing HDFS data, set the following options:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,7 +28,7 @@ The following steps must be followed to install Ansible and the prerequisites on
   ```
   sudo su -
   yum -y remove python-crypto
-  yum install http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+  yum -y install epel-release || yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
   yum repolist; yum install gcc gcc-c++ python-virtualenv python-pip python-devel sshpass git vim-enhanced -y
   ```
 
@@ -51,7 +51,7 @@ The following steps must be followed to install Ansible and the prerequisites on
 
   ```
   sudo su -
-  yum install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+  yum -y install epel-release || yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   yum repolist; yum install gcc gcc-c++ python-virtualenv python-pip python-devel sshpass git vim-enhanced -y
   ```
 
@@ -313,7 +313,7 @@ The following steps must be followed to install Ansible and the prerequisites on
 
   ```
   sudo su -
-  yum install http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+  yum -y install epel-release || yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
   yum repolist; yum install python-virtualenv python-pip python-devel sshpass git vim-enhanced -y
   ```
 
@@ -330,7 +330,7 @@ The following steps must be followed to install Ansible and the prerequisites on
 
   ```
   sudo su -
-  yum install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+  yum -y install epel-release || yum -y install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   yum repolist; yum install python-virtualenv python-pip python-devel sshpass git vim-enhanced -y
   ```
 

--- a/inventory/rax.py
+++ b/inventory/rax.py
@@ -355,12 +355,9 @@ def get_cache_file_path(regions):
 
 
 def _list(regions, refresh_cache=True):
-    cache_max_age = int(get_config(p, 'rax', 'cache_max_age',
-                                   'RAX_CACHE_MAX_AGE', 600))
-
     if (not os.path.exists(get_cache_file_path(regions)) or
         refresh_cache or
-        (time() - os.stat(get_cache_file_path(regions))[-1]) > cache_max_age):
+        (time() - os.stat(get_cache_file_path(regions))[-1]) > 600):
         # Cache file doesn't exist or older than 10m or refresh cache requested
         _list_into_cache(regions)
 
@@ -376,7 +373,7 @@ def parse_args():
     group.add_argument('--list', action='store_true',
                        help='List active servers')
     group.add_argument('--host', help='List details about the specific host')
-    parser.add_argument('--refresh-cache', action='store_true', default=False,
+    parser.add_argument('--refresh-cache', action='store_true', default=True,
                         help=('Force refresh of cache, making API requests to'
                               'RackSpace (default: False - use cache files)'))
     return parser.parse_args()

--- a/playbooks/bootstrap.yml
+++ b/playbooks/bootstrap.yml
@@ -1,12 +1,12 @@
 ---
 - include: create_groups.yml
 
-- name: "Apply the common role to all nodes"
+- name: Apply the common role to all nodes
   hosts: hadoop-cluster
   any_errors_fatal: true
   become: yes
   pre_tasks:
-    - name: "Show hadoop-cluster info"
+    - name: Show hadoop-cluster info
       debug: var=hostvars[inventory_hostname]
       when: debug
   roles:

--- a/playbooks/create_groups.yml
+++ b/playbooks/create_groups.yml
@@ -1,10 +1,10 @@
 ---
-- name: "Add nodes to required groups"
+- name: Add nodes to required groups
   hosts: localhost
   connection: local
   gather_facts: False
   tasks:
-    - name: "Add all cluster nodes to the hadoop-cluster group"
+    - name: Add all cluster nodes to the hadoop-cluster group
       always_run: yes
       add_host:
         name: "{{ hostvars[item].inventory_hostname }}"
@@ -20,7 +20,7 @@
         - "{{ groups['edge-nodes']|default([]) }}"
       when: "'hadoop-cluster' not in groups or groups['hadoop-cluster']|length < 1"
 
-    - name: "Add the last masternode to ambari-node variable group"
+    - name: Add the last masternode to ambari-node variable group
       always_run: yes
       add_host:
         name: "{{ hostvars[item].inventory_hostname }}"

--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -5,6 +5,8 @@ ambari_version: '2.2.2.0'
 admin_password: 'admin'
 services_password: 'AsdQwe123'
 alerts_contact: 'root@localhost.localdomain'
+wait: true
+wait_timeout: 1800   # 30 minutes
 
 install_spark: true
 install_flume: true

--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -1,7 +1,7 @@
 ---
 cluster_name: 'hadoop-poc'
 hdp_version: '2.4'
-ambari_version: '2.2.1.1'
+ambari_version: '2.2.2.0'
 admin_password: 'admin'
 services_password: 'AsdQwe123'
 alerts_contact: 'root@localhost.localdomain'

--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -1,11 +1,11 @@
 ---
 cluster_name: 'hadoop-poc'
 hdp_version: '2.4'
-custom_repo: false
-custom_repo_url: ''
-custom_repo_target: 'api/v1/stacks/HDP/versions/2.4/operating_systems/redhat6/repositories/HDP-2.4'
 ambari_version: '2.2.1.1'
-use_dns: false
+admin_password: 'admin'
+services_password: 'AsdQwe123'
+alerts_contact: 'root@localhost.localdomain'
+
 install_spark: true
 install_flume: true
 install_hbase: false
@@ -13,12 +13,14 @@ install_storm: true
 install_kafka: true
 install_falcon: true
 tachyon_service: false
-custom_blueprint: false
-admin_password: 'admin'
-services_password: 'AsdQwe123'
-alerts_contact: 'root@localhost.localdomain'
+
 data_disks_filesystem: xfs
 configure_firewall: false
+use_dns: false
+custom_blueprint: false
+custom_repo: false
+custom_repo_url: ''
+custom_repo_target: 'api/v1/stacks/HDP/versions/2.4/operating_systems/redhat6/repositories/HDP-2.4'
 
 spark_stack: false
 spark_stack_config:

--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -5,7 +5,6 @@ custom_repo: false
 custom_repo_url: ''
 custom_repo_target: 'api/v1/stacks/HDP/versions/2.4/operating_systems/redhat6/repositories/HDP-2.4'
 ambari_version: '2.2.1.1'
-spark_stack: false
 use_dns: false
 install_spark: true
 install_flume: true

--- a/playbooks/hortonworks.yml
+++ b/playbooks/hortonworks.yml
@@ -1,12 +1,12 @@
 ---
 - include: create_groups.yml
 
-- name: "Apply the ambari-agent role to all nodes"
+- name: Apply the ambari-agent role to all nodes
   hosts: hadoop-cluster
   any_errors_fatal: true
   become: yes
   pre_tasks:
-    - name: "Show hadoop-cluster info"
+    - name: Show hadoop-cluster info
       debug: var=hostvars[inventory_hostname]
       when: debug
   roles:
@@ -14,7 +14,7 @@
   tags:
     - ambari-agent-only
 
-- name: "Apply the ambari-server role to ambari-node group"
+- name: Apply the ambari-server role to ambari-node group
   hosts: ambari-node
   become: yes
   roles:

--- a/playbooks/hortonworks.yml
+++ b/playbooks/hortonworks.yml
@@ -19,5 +19,13 @@
   become: yes
   roles:
     - ambari-server
+  post_tasks:
+    - name: Cleanup the temporary files
+      file: path={{ item }} state=absent
+      with_items:
+        - /tmp/cluster_blueprint
+        - /tmp/cluster_template
+        - /tmp/alert_targets
+        - /tmp/hdprepo
   tags:
     - ambari-server-only

--- a/playbooks/provision_cbs.yml
+++ b/playbooks/provision_cbs.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Create CBS Volumes"
+- name: Create CBS Volumes
   local_action:
     module: rax_cbs
     credentials: "{{ cloud_config.rax_credentials_file }}"
@@ -13,7 +13,7 @@
     - "{{ rax.instances }}"
     - "{{ datanode_disks }}"
 
-- name: "Attach CBS Volumes"
+- name: Attach CBS Volumes
   local_action:
     module: rax_cbs_attachments
     credentials: "{{ cloud_config.rax_credentials_file }}"

--- a/playbooks/provision_rax.yml
+++ b/playbooks/provision_rax.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Build the environment"
+- name: Build the environment
   hosts: localhost
   connection: local
   gather_facts: False
@@ -15,7 +15,7 @@
     - name: Include master-nodes group variables
       include_vars: group_vars/master-nodes
 
-    - name: "Create master nodes"
+    - name: Create master nodes
       local_action:
         module: rax
         credentials: "{{ cloud_config.rax_credentials_file }}"
@@ -34,14 +34,14 @@
       register: rax
       when: cloud_nodes_count > 0
 
-    - name: "Build Rackspace CBS for master nodes"
+    - name: Build Rackspace CBS for master nodes
       include: provision_cbs.yml
       when: cloud_nodes_count > 0 and build_datanode_cbs is defined and build_datanode_cbs
 
     - name: Include slave-nodes group variables
       include_vars: group_vars/slave-nodes
 
-    - name: "Create slave nodes"
+    - name: Create slave nodes
       local_action:
         module: rax
         credentials: "{{ cloud_config.rax_credentials_file }}"
@@ -60,14 +60,14 @@
       register: rax
       when: cloud_nodes_count > 0
 
-    - name: "Build Rackspace CBS for slave nodes"
+    - name: Build Rackspace CBS for slave nodes
       include: provision_cbs.yml
       when: cloud_nodes_count > 0 and build_datanode_cbs is defined and build_datanode_cbs
 
     - name: Include edge-nodes group variables
       include_vars: group_vars/edge-nodes
 
-    - name: "Create edge nodes"
+    - name: Create edge nodes
       local_action:
         module: rax
         credentials: "{{ cloud_config.rax_credentials_file }}"

--- a/playbooks/roles/ambari-agent/handlers/main.yml
+++ b/playbooks/roles/ambari-agent/handlers/main.yml
@@ -1,8 +1,7 @@
 ---
-- name: reload systemd
+- name: Reload systemd
   command: systemctl daemon-reload
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
 
-- name: restart ambari-agent
+- name: Restart ambari-agent
   service: name=ambari-agent state=restarted
-  notify: sleep

--- a/playbooks/roles/ambari-agent/tasks/main.yml
+++ b/playbooks/roles/ambari-agent/tasks/main.yml
@@ -23,7 +23,7 @@
     state: installed
   with_items:
     - ambari-agent
-  notify: reload systemd
+  notify: Reload systemd
   when: ansible_os_family == "RedHat"
 
 - name: Ensure required packages are installed (apt)
@@ -40,7 +40,7 @@
               regexp='^hostname\s*='
               line='hostname={{ hostvars[groups['ambari-node'][0]]['ansible_nodename'] }}'
               state=present
-  notify: restart ambari-agent
+  notify: Restart ambari-agent
 
 - meta: flush_handlers
 

--- a/playbooks/roles/ambari-agent/tasks/main.yml
+++ b/playbooks/roles/ambari-agent/tasks/main.yml
@@ -35,12 +35,6 @@
     - ambari-agent
   when: ansible_os_family == "Debian"
 
-- name: Fix for upstart script in RHEL6
-  lineinfile: dest=/etc/init/ambari-agent.conf
-              state=absent
-              regexp='^kill(.*)'
-  when: ansible_os_family == "RedHat" and (ansible_distribution == "Amazon" or ansible_distribution_major_version == "6")
-
 - name: Configure the Ambari agent
   lineinfile: dest=/etc/ambari-agent/conf/ambari-agent.ini
               regexp='^hostname\s*='

--- a/playbooks/roles/ambari-server/handlers/main.yml
+++ b/playbooks/roles/ambari-server/handlers/main.yml
@@ -1,8 +1,7 @@
 ---
-- name: reload systemd
+- name: Reload systemd
   command: systemctl daemon-reload
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
 
-- name: restart ambari-server
+- name: Restart ambari-server
   service: name=ambari-server state=restarted
-  notify: sleep

--- a/playbooks/roles/ambari-server/tasks/main.yml
+++ b/playbooks/roles/ambari-server/tasks/main.yml
@@ -145,7 +145,7 @@
 
 - name: Check the cluster creation status
   fail: msg="Failed to build the {{ cluster_name }} cluster. Status is {{ (cluster_create_task.content|from_json).Requests.request_status }}"
-  when: ((cluster_create_task.content|from_json).Requests.request_status == 'FAILED' or
+  when: wait and ((cluster_create_task.content|from_json).Requests.request_status == 'FAILED' or
          (cluster_create_task.content|from_json).Requests.request_status == 'TIMEDOUT' or
          (cluster_create_task.content|from_json).Requests.request_status == 'ABORTED')
 

--- a/playbooks/roles/ambari-server/tasks/main.yml
+++ b/playbooks/roles/ambari-server/tasks/main.yml
@@ -1,13 +1,17 @@
 ---
-- include: prerequisites.yml
+- name: Include prerequisites.yml
+  include: prerequisites.yml
 
-- include: single-node.yml
+- name: Include single-node.yml
+  include: single-node.yml
   when: not custom_blueprint and groups['master-nodes']|length == 1 and ('slave-nodes' not in groups or groups['slave-nodes']|length == 0)
 
-- include: multi-nodes.yml
+- name: Include multi-nodes.yml
+  include: multi-nodes.yml
   when: not custom_blueprint and groups['master-nodes']|length > 0 and 'slave-nodes' in groups and groups['slave-nodes']|length > 0
 
-- include: custom.yml
+- name: Include custom.yml
+  include: custom.yml
   when: custom_blueprint
 
 - name: Upload HDP Repo

--- a/playbooks/roles/ambari-server/tasks/main.yml
+++ b/playbooks/roles/ambari-server/tasks/main.yml
@@ -143,7 +143,7 @@
   delay: 10
   when: wait
 
-- name: Check the cluster creation status
+- name: Fail if the cluster create task is in an error state
   fail: msg="Failed to build the {{ cluster_name }} cluster. Status is {{ (cluster_create_task.content|from_json).Requests.request_status }}"
   when: wait and ((cluster_create_task.content|from_json).Requests.request_status == 'FAILED' or
          (cluster_create_task.content|from_json).Requests.request_status == 'TIMEDOUT' or

--- a/playbooks/roles/ambari-server/tasks/main.yml
+++ b/playbooks/roles/ambari-server/tasks/main.yml
@@ -23,7 +23,7 @@
   register: hdprepo
   when: custom_repo
 
-- name: modify repo base_url
+- name: Modify repo base_url
   uri: url=http://{{ ansible_nodename }}:8080/{{ custom_repo_target }}
        method=PUT
        force_basic_auth=yes

--- a/playbooks/roles/ambari-server/tasks/main.yml
+++ b/playbooks/roles/ambari-server/tasks/main.yml
@@ -102,6 +102,16 @@
   slurp: src=/tmp/cluster_template
   register: cluster_template
 
+- name: Check if a cluster {{ cluster_name }} already exists
+  uri: url=http://{{ ansible_nodename }}:8080/api/v1/clusters/{{ cluster_name }}
+       method=GET
+       force_basic_auth=yes
+       user=admin
+       password=admin
+       HEADER_X-Requested-By="ambari"
+       status_code=200,201,202,404
+  register: current_cluster
+
 - name: Create the cluster instance
   uri: url=http://{{ ansible_nodename }}:8080/api/v1/clusters/{{ cluster_name }}
        method=POST
@@ -112,6 +122,7 @@
        body=" {{ cluster_template.content | b64decode }}"
        body_format=raw
        status_code=200,201,202
+  when: current_cluster.status==404
 
 - name: Change Ambari admin user password
   uri: url=http://{{ ansible_nodename }}:8080/api/v1/users/admin

--- a/playbooks/roles/ambari-server/tasks/main.yml
+++ b/playbooks/roles/ambari-server/tasks/main.yml
@@ -124,6 +124,31 @@
        status_code=200,201,202
   when: current_cluster.status==404
 
+- name: Wait for the cluster to be built
+  uri: url=http://{{ ansible_nodename }}:8080/api/v1/clusters/{{ cluster_name }}/requests/1
+       method=GET
+       force_basic_auth=yes
+       user=admin
+       password=admin
+       HEADER_Content-Type="application/json"
+       HEADER_X-Requested-By="ambari"
+       status_code=200,201,202
+       return_content=yes
+  register: cluster_create_task
+  until: ((cluster_create_task.content|from_json).Requests.request_status == 'COMPLETED' or
+         (cluster_create_task.content|from_json).Requests.request_status == 'FAILED' or
+         (cluster_create_task.content|from_json).Requests.request_status == 'TIMEDOUT' or
+         (cluster_create_task.content|from_json).Requests.request_status == 'ABORTED')
+  retries: "{{ wait_timeout // 10 }}"
+  delay: 10
+  when: wait
+
+- name: Check the cluster creation status
+  fail: msg="Failed to build the {{ cluster_name }} cluster. Status is {{ (cluster_create_task.content|from_json).Requests.request_status }}"
+  when: ((cluster_create_task.content|from_json).Requests.request_status == 'FAILED' or
+         (cluster_create_task.content|from_json).Requests.request_status == 'TIMEDOUT' or
+         (cluster_create_task.content|from_json).Requests.request_status == 'ABORTED')
+
 - name: Change Ambari admin user password
   uri: url=http://{{ ansible_nodename }}:8080/api/v1/users/admin
        method=PUT

--- a/playbooks/roles/ambari-server/tasks/prerequisites.yml
+++ b/playbooks/roles/ambari-server/tasks/prerequisites.yml
@@ -20,7 +20,8 @@
 
 - meta: flush_handlers
 
-- include: spark_stack.yml
+- name: Include spark_stack.yml
+  include: spark_stack.yml
   when: spark_stack and ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
 
 - name: Run Ambari Server setup

--- a/playbooks/roles/ambari-server/tasks/prerequisites.yml
+++ b/playbooks/roles/ambari-server/tasks/prerequisites.yml
@@ -6,7 +6,7 @@
     state: installed
   with_items:
     - ambari-server
-  notify: reload systemd
+  notify: Reload systemd
   when: ansible_os_family == "RedHat"
 
 - name: Ensure required packages are installed (apt)

--- a/playbooks/roles/ambari-server/templates/blueprint-custom.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-custom.j2
@@ -125,6 +125,9 @@
           "name" : "METRICS_COLLECTOR"
         },
         {
+          "name" : "METRICS_GRAFANA"
+        },
+        {
           "name" : "METRICS_MONITOR"
         }
       ],

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
@@ -23,6 +23,13 @@
       }
     },
     {
+      "hive-env" : {
+        "hive.heapsize" : "4096",
+        "hive.metastore.heapsize" : "2048",
+        "hive.client.heapsize" : "1024"
+      }
+    },
+    {
       "hadoop-env" : {
         "dtnode_heapsize" : "2048m",
         "namenode_heapsize" : "8192m",
@@ -42,6 +49,13 @@
     {
       "ams-env" : {
         "metrics_collector_heapsize" : "2048m"
+      }
+    },
+    {
+      "hive-env" : {
+        "hive.heapsize" : "2048",
+        "hive.metastore.heapsize" : "1024",
+        "hive.client.heapsize" : "1024"
       }
     },
     {

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
@@ -594,6 +594,9 @@
           "name" : "SPARK_JOBHISTORYSERVER"
         },
         {
+          "name" : "SPARK_THRIFTSERVER"
+        },
+        {
           "name" : "SPARK_CLIENT"
         },
         {% endif -%}

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
@@ -8,7 +8,29 @@
         "hadoop.proxyuser.hue.hosts" : "*"
       }
     },
-    {% if hostvars[groups['master-nodes'][0]]['ansible_memtotal_mb'] > 40000 -%}
+    {% if hostvars[groups['master-nodes'][0]]['ansible_memtotal_mb'] > 119000 -%}
+    {
+      "ams-hbase-env" : {
+        "regionserver_xmn_size" : "512m",
+        "hbase_regionserver_heapsize" : "4096m",
+        "hbase_master_heapsize" : "4096m",
+        "hbase_master_xmn_size" : "512m"
+      }
+    },
+    {
+      "ams-env" : {
+        "metrics_collector_heapsize" : "2048m"
+      }
+    },
+    {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "2048m",
+        "namenode_heapsize" : "8192m",
+        "namenode_opt_maxnewsize" : "512m",
+        "namenode_opt_newsize" : "512m"
+      }
+    },
+    {% elif hostvars[groups['master-nodes'][0]]['ansible_memtotal_mb'] > 40000 -%}
     {
       "ams-hbase-env" : {
         "regionserver_xmn_size" : "512m",

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
@@ -31,7 +31,6 @@
     },
     {
       "hadoop-env" : {
-        "dtnode_heapsize" : "2048m",
         "namenode_heapsize" : "8192m",
         "namenode_opt_maxnewsize" : "512m",
         "namenode_opt_newsize" : "512m"
@@ -60,7 +59,6 @@
     },
     {
       "hadoop-env" : {
-        "dtnode_heapsize" : "2048m",
         "namenode_heapsize" : "4096m",
         "namenode_opt_maxnewsize" : "512m",
         "namenode_opt_newsize" : "512m"
@@ -82,7 +80,6 @@
     },
     {
       "hadoop-env" : {
-        "dtnode_heapsize" : "1024m",
         "namenode_heapsize" : "2048m",
         "namenode_opt_maxnewsize" : "384m",
         "namenode_opt_newsize" : "384m"
@@ -101,6 +98,11 @@
       }
     },
     {% if hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 119000 -%}
+    {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "4096m"
+      }
+    },
     {
       "yarn-site" : {
         {% if install_hbase == true -%}
@@ -150,6 +152,11 @@
     },
     {% elif hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 59000 -%}
     {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "2048m"
+      }
+    },
+    {
       "yarn-site" : {
         {% if install_hbase == true -%}
         "yarn.nodemanager.resource.memory-mb" : "{{ ((hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] - 8192 - hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb']//8)//4096)*4096 }}",
@@ -197,6 +204,11 @@
         }
     },
     {% elif hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 24000 -%}
+    {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "1024m"
+      }
+    },
     {
       "yarn-site" : {
         {% if install_hbase == true -%}

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
@@ -30,6 +30,11 @@
       }
     },
     {
+      "hbase-env" : {
+        "hbase_master_heapsize" : "4096m"
+        }
+    },
+    {
       "hadoop-env" : {
         "namenode_heapsize" : "8192m",
         "namenode_opt_maxnewsize" : "512m",
@@ -58,6 +63,11 @@
       }
     },
     {
+      "hbase-env" : {
+        "hbase_master_heapsize" : "2048m"
+        }
+    },
+    {
       "hadoop-env" : {
         "namenode_heapsize" : "4096m",
         "namenode_opt_maxnewsize" : "512m",
@@ -77,6 +87,11 @@
       "ams-env" : {
         "metrics_collector_heapsize" : "1024m"
       }
+    },
+    {
+      "hbase-env" : {
+        "hbase_master_heapsize" : "1024m"
+        }
     },
     {
       "hadoop-env" : {
@@ -145,9 +160,8 @@
     },
     {
       "hbase-env" : {
-        "hbase_master_heapsize" : "4096m",
         "hbase_regionserver_heapsize" : "16384m",
-        "hbase_regionserver_xmn_max" : "3276"
+        "hbase_regionserver_xmn_max" : "2048"
         }
     },
     {% elif hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 59000 -%}
@@ -198,9 +212,8 @@
     },
     {
       "hbase-env" : {
-        "hbase_master_heapsize" : "2048m",
         "hbase_regionserver_heapsize" : "8192m",
-        "hbase_regionserver_xmn_max" : "2048"
+        "hbase_regionserver_xmn_max" : "1536"
         }
     },
     {% elif hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 24000 -%}
@@ -251,9 +264,8 @@
     },
     {
       "hbase-env" : {
-        "hbase_master_heapsize" : "1024m",
         "hbase_regionserver_heapsize" : "4096m",
-        "hbase_regionserver_xmn_max" : "1024"
+        "hbase_regionserver_xmn_max" : "768"
         }
     },
     {% endif -%}

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
@@ -541,6 +541,9 @@
           "name" : "METRICS_COLLECTOR"
         },
         {
+          "name" : "METRICS_GRAFANA"
+        },
+        {
           "name" : "RESOURCEMANAGER"
         },
         {

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
@@ -36,6 +36,11 @@
       }
     },
     {
+      "hbase-env" : {
+        "hbase_master_heapsize" : "8192m"
+        }
+    },
+    {
       "hadoop-env" : {
         "namenode_heapsize" : "8192m",
         "namenode_opt_maxnewsize" : "512m",
@@ -64,6 +69,11 @@
       }
     },
     {
+      "hbase-env" : {
+        "hbase_master_heapsize" : "4096m"
+        }
+    },
+    {
       "hadoop-env" : {
         "namenode_heapsize" : "4096m",
         "namenode_opt_maxnewsize" : "512m",
@@ -90,6 +100,11 @@
         "hive.metastore.heapsize" : "1024",
         "hive.client.heapsize" : "1024"
       }
+    },
+    {
+      "hbase-env" : {
+        "hbase_master_heapsize" : "1024m"
+        }
     },
     {
       "hadoop-env" : {
@@ -179,9 +194,8 @@
     },
     {
       "hbase-env" : {
-        "hbase_master_heapsize" : "4096m",
         "hbase_regionserver_heapsize" : "16384m",
-        "hbase_regionserver_xmn_max" : "3276"
+        "hbase_regionserver_xmn_max" : "2048"
         }
     },
     {% elif hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 59000 -%}
@@ -232,9 +246,8 @@
     },
     {
       "hbase-env" : {
-        "hbase_master_heapsize" : "2048m",
         "hbase_regionserver_heapsize" : "8192m",
-        "hbase_regionserver_xmn_max" : "2048"
+        "hbase_regionserver_xmn_max" : "1536"
         }
     },
     {% elif hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 24000 -%}
@@ -285,9 +298,8 @@
     },
     {
       "hbase-env" : {
-        "hbase_master_heapsize" : "1024m",
         "hbase_regionserver_heapsize" : "4096m",
-        "hbase_regionserver_xmn_max" : "1024"
+        "hbase_regionserver_xmn_max" : "768"
         }
     },
     {% endif -%}

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
@@ -527,6 +527,9 @@
           "name" : "SPARK_JOBHISTORYSERVER"
         },
         {
+          "name" : "SPARK_THRIFTSERVER"
+        },
+        {
           "name" : "SPARK_CLIENT"
         },
         {% endif -%}

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
@@ -37,7 +37,6 @@
     },
     {
       "hadoop-env" : {
-        "dtnode_heapsize" : "2048m",
         "namenode_heapsize" : "8192m",
         "namenode_opt_maxnewsize" : "512m",
         "namenode_opt_newsize" : "512m"
@@ -66,7 +65,6 @@
     },
     {
       "hadoop-env" : {
-        "dtnode_heapsize" : "2048m",
         "namenode_heapsize" : "4096m",
         "namenode_opt_maxnewsize" : "512m",
         "namenode_opt_newsize" : "512m"
@@ -95,7 +93,6 @@
     },
     {
       "hadoop-env" : {
-        "dtnode_heapsize" : "1024m",
         "namenode_heapsize" : "2048m",
         "namenode_opt_maxnewsize" : "384m",
         "namenode_opt_newsize" : "384m"
@@ -135,6 +132,11 @@
     },
     {% endif -%}
     {% if hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 119000 -%}
+    {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "4096m"
+      }
+    },
     {
       "yarn-site" : {
         {% if install_hbase == true -%}
@@ -184,6 +186,11 @@
     },
     {% elif hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 59000 -%}
     {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "2048m"
+      }
+    },
+    {
       "yarn-site" : {
         {% if install_hbase == true -%}
         "yarn.nodemanager.resource.memory-mb" : "{{ ((hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] - 8192 - hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb']//8)//4096)*4096 }}",
@@ -231,6 +238,11 @@
         }
     },
     {% elif hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 24000 -%}
+    {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "1024m"
+      }
+    },
     {
       "yarn-site" : {
         {% if install_hbase == true -%}

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
@@ -512,6 +512,9 @@
           "name" : "METRICS_COLLECTOR"
         },
         {
+          "name" : "METRICS_GRAFANA"
+        },
+        {
           "name" : "RESOURCEMANAGER"
         },
         {% if install_flume == true -%}

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
@@ -14,7 +14,29 @@
         "hadoop.proxyuser.hue.hosts" : "*"
       }
     },
-    {% if hostvars[groups['master-nodes'][0]]['ansible_memtotal_mb'] > 24000 -%}
+    {% if hostvars[groups['master-nodes'][0]]['ansible_memtotal_mb'] > 89000 -%}
+    {
+      "ams-hbase-env" : {
+        "regionserver_xmn_size" : "512m",
+        "hbase_regionserver_heapsize" : "4096m",
+        "hbase_master_heapsize" : "4096m",
+        "hbase_master_xmn_size" : "512m"
+      }
+    },
+    {
+      "ams-env" : {
+        "metrics_collector_heapsize" : "2048m"
+      }
+    },
+    {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "2048m",
+        "namenode_heapsize" : "8192m",
+        "namenode_opt_maxnewsize" : "512m",
+        "namenode_opt_newsize" : "512m"
+      }
+    },
+    {% elif hostvars[groups['master-nodes'][0]]['ansible_memtotal_mb'] > 24000 -%}
     {
       "ams-hbase-env" : {
         "regionserver_xmn_size" : "512m",

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
@@ -25,7 +25,14 @@
     },
     {
       "ams-env" : {
-        "metrics_collector_heapsize" : "2048m"
+        "metrics_collector_heapsize" : "4096m"
+      }
+    },
+    {
+      "hive-env" : {
+        "hive.heapsize" : "8192",
+        "hive.metastore.heapsize" : "8192",
+        "hive.client.heapsize" : "2048"
       }
     },
     {
@@ -51,6 +58,13 @@
       }
     },
     {
+      "hive-env" : {
+        "hive.heapsize" : "4096",
+        "hive.metastore.heapsize" : "1024",
+        "hive.client.heapsize" : "1024"
+      }
+    },
+    {
       "hadoop-env" : {
         "dtnode_heapsize" : "2048m",
         "namenode_heapsize" : "4096m",
@@ -70,6 +84,13 @@
     {
       "ams-env" : {
         "metrics_collector_heapsize" : "1024m"
+      }
+    },
+    {
+      "hive-env" : {
+        "hive.heapsize" : "1024",
+        "hive.metastore.heapsize" : "1024",
+        "hive.client.heapsize" : "1024"
       }
     },
     {

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
@@ -36,6 +36,11 @@
       }
     },
     {
+      "hbase-env" : {
+        "hbase_master_heapsize" : "8192m"
+        }
+    },
+    {
       "hadoop-env" : {
         "namenode_heapsize" : "8192m",
         "namenode_opt_maxnewsize" : "512m",
@@ -64,6 +69,11 @@
       }
     },
     {
+      "hbase-env" : {
+        "hbase_master_heapsize" : "4096m"
+        }
+    },
+    {
       "hadoop-env" : {
         "namenode_heapsize" : "4096m",
         "namenode_opt_maxnewsize" : "512m",
@@ -90,6 +100,11 @@
         "hive.metastore.heapsize" : "1024",
         "hive.client.heapsize" : "1024"
       }
+    },
+    {
+      "hbase-env" : {
+        "hbase_master_heapsize" : "1024m"
+        }
     },
     {
       "hadoop-env" : {
@@ -179,9 +194,8 @@
     },
     {
       "hbase-env" : {
-        "hbase_master_heapsize" : "4096m",
         "hbase_regionserver_heapsize" : "16384m",
-        "hbase_regionserver_xmn_max" : "3276"
+        "hbase_regionserver_xmn_max" : "2048"
         }
     },
     {% elif hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 59000 -%}
@@ -232,9 +246,8 @@
     },
     {
       "hbase-env" : {
-        "hbase_master_heapsize" : "2048m",
         "hbase_regionserver_heapsize" : "8192m",
-        "hbase_regionserver_xmn_max" : "2048"
+        "hbase_regionserver_xmn_max" : "1536"
         }
     },
     {% elif hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 24000 -%}
@@ -285,9 +298,8 @@
     },
     {
       "hbase-env" : {
-        "hbase_master_heapsize" : "1024m",
         "hbase_regionserver_heapsize" : "4096m",
-        "hbase_regionserver_xmn_max" : "1024"
+        "hbase_regionserver_xmn_max" : "768"
         }
     },
     {% endif -%}

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
@@ -37,7 +37,6 @@
     },
     {
       "hadoop-env" : {
-        "dtnode_heapsize" : "2048m",
         "namenode_heapsize" : "8192m",
         "namenode_opt_maxnewsize" : "512m",
         "namenode_opt_newsize" : "512m"
@@ -66,7 +65,6 @@
     },
     {
       "hadoop-env" : {
-        "dtnode_heapsize" : "2048m",
         "namenode_heapsize" : "4096m",
         "namenode_opt_maxnewsize" : "512m",
         "namenode_opt_newsize" : "512m"
@@ -95,7 +93,6 @@
     },
     {
       "hadoop-env" : {
-        "dtnode_heapsize" : "1024m",
         "namenode_heapsize" : "2048m",
         "namenode_opt_maxnewsize" : "384m",
         "namenode_opt_newsize" : "384m"
@@ -135,6 +132,11 @@
     },
     {% endif -%}
     {% if hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 119000 -%}
+    {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "4096m"
+      }
+    },
     {
       "yarn-site" : {
         {% if install_hbase == true -%}
@@ -184,6 +186,11 @@
     },
     {% elif hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 59000 -%}
     {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "2048m"
+      }
+    },
+    {
       "yarn-site" : {
         {% if install_hbase == true -%}
         "yarn.nodemanager.resource.memory-mb" : "{{ ((hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] - 8192 - hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb']//8)//4096)*4096 }}",
@@ -231,6 +238,11 @@
         }
     },
     {% elif hostvars[groups['slave-nodes'][0]]['ansible_memtotal_mb'] > 24000 -%}
+    {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "1024m"
+      }
+    },
     {
       "yarn-site" : {
         {% if install_hbase == true -%}

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
@@ -590,6 +590,9 @@
         {
           "name" : "METRICS_COLLECTOR"
         },
+        {
+          "name" : "METRICS_GRAFANA"
+        },
         {% if hdfs.ha_namenode -%}
         {
           "name" : "JOURNALNODE"

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
@@ -812,6 +812,9 @@
           "name" : "SPARK_JOBHISTORYSERVER"
         },
         {
+          "name" : "SPARK_THRIFTSERVER"
+        },
+        {
           "name" : "SPARK_CLIENT"
         },
         {% endif -%}

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
@@ -14,7 +14,29 @@
         "hadoop.proxyuser.hue.hosts" : "*"
       }
     },
-    {% if hostvars[groups['master-nodes'][0]]['ansible_memtotal_mb'] > 24000 -%}
+    {% if hostvars[groups['master-nodes'][0]]['ansible_memtotal_mb'] > 89000 -%}
+    {
+      "ams-hbase-env" : {
+        "regionserver_xmn_size" : "512m",
+        "hbase_regionserver_heapsize" : "4096m",
+        "hbase_master_heapsize" : "4096m",
+        "hbase_master_xmn_size" : "512m"
+      }
+    },
+    {
+      "ams-env" : {
+        "metrics_collector_heapsize" : "2048m"
+      }
+    },
+    {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "2048m",
+        "namenode_heapsize" : "8192m",
+        "namenode_opt_maxnewsize" : "512m",
+        "namenode_opt_newsize" : "512m"
+      }
+    },
+    {% elif hostvars[groups['master-nodes'][0]]['ansible_memtotal_mb'] > 24000 -%}
     {
       "ams-hbase-env" : {
         "regionserver_xmn_size" : "512m",

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
@@ -25,7 +25,14 @@
     },
     {
       "ams-env" : {
-        "metrics_collector_heapsize" : "2048m"
+        "metrics_collector_heapsize" : "4096m"
+      }
+    },
+    {
+      "hive-env" : {
+        "hive.heapsize" : "8192",
+        "hive.metastore.heapsize" : "8192",
+        "hive.client.heapsize" : "2048"
       }
     },
     {
@@ -51,6 +58,13 @@
       }
     },
     {
+      "hive-env" : {
+        "hive.heapsize" : "4096",
+        "hive.metastore.heapsize" : "1024",
+        "hive.client.heapsize" : "1024"
+      }
+    },
+    {
       "hadoop-env" : {
         "dtnode_heapsize" : "2048m",
         "namenode_heapsize" : "4096m",
@@ -70,6 +84,13 @@
     {
       "ams-env" : {
         "metrics_collector_heapsize" : "1024m"
+      }
+    },
+    {
+      "hive-env" : {
+        "hive.heapsize" : "1024",
+        "hive.metastore.heapsize" : "1024",
+        "hive.client.heapsize" : "1024"
       }
     },
     {

--- a/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
@@ -409,6 +409,9 @@
           "name" : "SPARK_JOBHISTORYSERVER"
         },
         {
+          "name" : "SPARK_THRIFTSERVER"
+        },
+        {
           "name" : "SPARK_CLIENT"
         },
         {% endif -%}

--- a/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
@@ -31,7 +31,6 @@
     },
     {
       "hadoop-env" : {
-        "dtnode_heapsize" : "2048m",
         "namenode_heapsize" : "4096m",
         "namenode_opt_maxnewsize" : "512m",
         "namenode_opt_newsize" : "512m"
@@ -60,7 +59,6 @@
     },
     {
       "hadoop-env" : {
-        "dtnode_heapsize" : "2048m",
         "namenode_heapsize" : "2048m",
         "namenode_opt_maxnewsize" : "384m",
         "namenode_opt_newsize" : "384m"
@@ -79,6 +77,11 @@
       }
     },
     {% if ansible_memtotal_mb > 119000 -%}
+    {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "2048m"
+      }
+    },
     {
       "yarn-site" : {
         {% if install_hbase == true -%}
@@ -128,6 +131,11 @@
     },
     {% elif ansible_memtotal_mb > 59000 -%}
     {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "2048m"
+      }
+    },
+    {
       "yarn-site" : {
         {% if install_hbase == true -%}
         "yarn.nodemanager.resource.memory-mb" : "{{ ((ansible_memtotal_mb - 35000 - ansible_memtotal_mb//6)//2048)*2048 }}",
@@ -175,6 +183,11 @@
         }
     },
     {% elif ansible_memtotal_mb > 24000 -%}
+    {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "1024m"
+      }
+    },
     {
       "yarn-site" : {
         {% if install_hbase == true -%}

--- a/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
@@ -347,6 +347,9 @@
           "name" : "METRICS_COLLECTOR"
         },
         {
+          "name" : "METRICS_GRAFANA"
+        },
+        {
           "name" : "RESOURCEMANAGER"
         },
         {

--- a/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
@@ -188,6 +188,11 @@
     },
     {% endif -%}
     {
+      "yarn-site" : {
+        "yarn.nodemanager.local-dirs" : "{% for disk in ansible_mounts if disk.mount | match("/grid/*") %}{{ disk.mount }}/hadoop/yarn/local{% if not loop.last %},{% endif %}{% else %}/hadoop/yarn/local{%- endfor %}",
+        "yarn.nodemanager.log-dirs" : "{% for disk in ansible_mounts if disk.mount | match("/grid/*") %}{{ disk.mount }}/hadoop/yarn/log{% if not loop.last %},{% endif %}{% else %}/hadoop/yarn/log{%- endfor %}"      }
+    },
+    {
       "kafka-broker" : {
         "log.dirs" : "/hadoop/kafka-logs"
       }

--- a/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
@@ -30,6 +30,11 @@
       }
     },
     {
+      "hbase-env" : {
+        "hbase_master_heapsize" : "2048m"
+        }
+    },
+    {
       "hadoop-env" : {
         "namenode_heapsize" : "4096m",
         "namenode_opt_maxnewsize" : "512m",
@@ -56,6 +61,11 @@
         "hive.metastore.heapsize" : "1024",
         "hive.client.heapsize" : "1024"
       }
+    },
+    {
+      "hbase-env" : {
+        "hbase_master_heapsize" : "2048m"
+        }
     },
     {
       "hadoop-env" : {
@@ -124,9 +134,8 @@
     },
     {
       "hbase-env" : {
-        "hbase_master_heapsize" : "2048m",
         "hbase_regionserver_heapsize" : "8192m",
-        "hbase_regionserver_xmn_max" : "2048"
+        "hbase_regionserver_xmn_max" : "1536"
         }
     },
     {% elif ansible_memtotal_mb > 59000 -%}
@@ -177,9 +186,8 @@
     },
     {
       "hbase-env" : {
-        "hbase_master_heapsize" : "2048m",
         "hbase_regionserver_heapsize" : "4096m",
-        "hbase_regionserver_xmn_max" : "1024"
+        "hbase_regionserver_xmn_max" : "768"
         }
     },
     {% elif ansible_memtotal_mb > 24000 -%}
@@ -230,7 +238,6 @@
     },
     {
       "hbase-env" : {
-        "hbase_master_heapsize" : "1024m",
         "hbase_regionserver_heapsize" : "2048m",
         "hbase_regionserver_xmn_max" : "512"
         }

--- a/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
@@ -64,7 +64,7 @@
     },
     {
       "hbase-env" : {
-        "hbase_master_heapsize" : "2048m"
+        "hbase_master_heapsize" : "1024m"
         }
     },
     {
@@ -141,17 +141,17 @@
     {% elif ansible_memtotal_mb > 59000 -%}
     {
       "hadoop-env" : {
-        "dtnode_heapsize" : "2048m"
+        "dtnode_heapsize" : "1024m"
       }
     },
     {
       "yarn-site" : {
         {% if install_hbase == true -%}
-        "yarn.nodemanager.resource.memory-mb" : "{{ ((ansible_memtotal_mb - 35000 - ansible_memtotal_mb//6)//2048)*2048 }}",
-        "yarn.scheduler.maximum-allocation-mb" : "{{ ((ansible_memtotal_mb  - 35000 - 2048 - ansible_memtotal_mb//6)//2048)*2048 }}",
+        "yarn.nodemanager.resource.memory-mb" : "{{ ((ansible_memtotal_mb - 25000 - ansible_memtotal_mb//6)//2048)*2048 }}",
+        "yarn.scheduler.maximum-allocation-mb" : "{{ ((ansible_memtotal_mb  - 25000 - 2048 - ansible_memtotal_mb//6)//2048)*2048 }}",
         {% else -%}
-        "yarn.nodemanager.resource.memory-mb" : "{{ ((ansible_memtotal_mb - 30000 - ansible_memtotal_mb//6)//2048)*2048 }}",
-        "yarn.scheduler.maximum-allocation-mb" : "{{ ((ansible_memtotal_mb - 30000 - 2048 - ansible_memtotal_mb//6)//2048)*2048 }}",
+        "yarn.nodemanager.resource.memory-mb" : "{{ ((ansible_memtotal_mb - 20000 - ansible_memtotal_mb//6)//2048)*2048 }}",
+        "yarn.scheduler.maximum-allocation-mb" : "{{ ((ansible_memtotal_mb - 20000 - 2048 - ansible_memtotal_mb//6)//2048)*2048 }}",
         {% endif -%}
         "yarn.scheduler.minimum-allocation-mb" : "2048"
       }

--- a/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
@@ -8,7 +8,29 @@
         "hadoop.proxyuser.hue.hosts" : "*"
       }
     },
-    {% if ansible_memtotal_mb > 59000 -%}
+    {% if ansible_memtotal_mb > 119000 -%}
+    {
+      "ams-hbase-env" : {
+        "regionserver_xmn_size" : "512m",
+        "hbase_regionserver_heapsize" : "2048m",
+        "hbase_master_heapsize" : "2048m",
+        "hbase_master_xmn_size" : "512m"
+      }
+    },
+    {
+      "ams-env" : {
+        "metrics_collector_heapsize" : "2048m"
+      }
+    },
+    {
+      "hadoop-env" : {
+        "dtnode_heapsize" : "2048m",
+        "namenode_heapsize" : "4096m",
+        "namenode_opt_maxnewsize" : "512m",
+        "namenode_opt_newsize" : "512m"
+      }
+    },
+    {% elif ansible_memtotal_mb > 59000 -%}
     {
       "ams-hbase-env" : {
         "regionserver_xmn_size" : "384m",

--- a/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
@@ -23,6 +23,13 @@
       }
     },
     {
+      "hive-env" : {
+        "hive.heapsize" : "4096",
+        "hive.metastore.heapsize" : "2048",
+        "hive.client.heapsize" : "1024"
+      }
+    },
+    {
       "hadoop-env" : {
         "dtnode_heapsize" : "2048m",
         "namenode_heapsize" : "4096m",
@@ -42,6 +49,13 @@
     {
       "ams-env" : {
         "metrics_collector_heapsize" : "1024m"
+      }
+    },
+    {
+      "hive-env" : {
+        "hive.heapsize" : "2048",
+        "hive.metastore.heapsize" : "1024",
+        "hive.client.heapsize" : "1024"
       }
     },
     {

--- a/playbooks/roles/common/handlers/main.yml
+++ b/playbooks/roles/common/handlers/main.yml
@@ -4,7 +4,6 @@
 
 - name: Reload firewalld
   command: firewall-cmd --reload
-  notify: Gather facts
 
 - name: Run update-grub
   shell: "{{ update_grub }}"
@@ -19,13 +18,9 @@
   with_flattened:
     - cluster_interface
     - bond_interfaces
-  notify: Gather facts
 
 - name: Restart unbound
   service: name=unbound state=restarted enabled=yes
-
-- name: Gather facts
-  action: setup
 
 - name: Run depmod
   command: depmod

--- a/playbooks/roles/common/handlers/main.yml
+++ b/playbooks/roles/common/handlers/main.yml
@@ -2,9 +2,17 @@
 - name: Restart iptables
   service: name=iptables state=restarted enabled=yes
 
-- name: reload firewalld
+- name: Reload firewalld
   command: firewall-cmd --reload
   notify: Gather facts
+
+- name: Run update-grub
+  shell: "{{ update_grub }}"
+  when: "{{ ansible_distribution_major_version|int }} > 6"
+
+- name: Run resolvconf
+  shell: resolvconf -u
+  when: ansible_os_family == "Debian"
 
 - name: Restart network interfaces
   shell: ifdown {{ item }}; ifup {{ item }}; ifup {{ cluster_interface }}

--- a/playbooks/roles/common/handlers/main.yml
+++ b/playbooks/roles/common/handlers/main.yml
@@ -8,7 +8,7 @@
 
 - name: Run update-grub
   shell: "{{ update_grub }}"
-  when: "{{ ansible_distribution_major_version|int }} > 6"
+  when: ansible_distribution_major_version|int > 6
 
 - name: Run resolvconf
   shell: resolvconf -u

--- a/playbooks/roles/common/tasks/firewall.yml
+++ b/playbooks/roles/common/tasks/firewall.yml
@@ -21,14 +21,14 @@
   command: firewall-cmd --permanent --zone=public --add-rich-rule='rule family="ipv4" source address="{{ hostvars[item]['ansible_'~hostvars[item].cluster_interface|default(hostvars[item].ansible_default_ipv4.alias)]['ipv4']['address'] }}" accept'
 #  firewalld: source={{ hostvars[item][['ansible_', hostvars[item]['cluster_interface']]|join]['ipv4']['address'] }} state=enabled
   with_items: "{{ play_hosts }}"
-  notify: reload firewalld
+  notify: Reload firewalld
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
 
 - name: Set firewalld to allow cluster access from external IPs
   command: firewall-cmd --permanent --zone=public --add-rich-rule='rule family="ipv4" source address="{{ item }}" accept'
 #  firewalld: source={{ item }} state=enabled
   with_items: "{{ cloud_config.allowed_external_ips }}"
-  notify: reload firewalld
+  notify: Reload firewalld
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
 
 - name: Set UFW rules between cluster nodes

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -30,24 +30,24 @@
     name: "{{ item }}"
     update_cache: yes
     state: installed
-  with_items: "{{ packages }}"
-  when: ansible_os_family == "RedHat" and "{{ packages|length > 0 }}"
+  with_items: "{{ packages|default([]) }}"
+  when: ansible_os_family == "RedHat"
 
 - name: Ensure required packages are installed (apt)
   apt:
     name: "{{ item }}"
     update_cache: yes
     state: installed
-  with_items: "{{ packages }}"
-  when: ansible_os_family == "Debian" and "{{ packages|length > 0 }}"
+  with_items: "{{ packages|default([]) }}"
+  when: ansible_os_family == "Debian"
 
 - name: Upgrade all packages (yum)
   yum: name=* state=latest
-  when: ansible_os_family == "RedHat" and "{{ packages|length > 0 }}"
+  when: ansible_os_family == "RedHat"
 
 - name: Upgrade all packages (apt)
   apt: upgrade=dist
-  when: ansible_os_family == "Debian" and "{{ packages|length > 0 }}"
+  when: ansible_os_family == "Debian"
 
 - name: Include spark_stack.yml
   include: spark_stack.yml
@@ -119,7 +119,7 @@
   lineinfile: dest=/etc/default/grub
               state=present
               line='GRUB_CMDLINE_LINUX=$GRUB_CMDLINE_LINUX" transparent_hugepage=never"'
-  when: "{{ ansible_distribution_major_version|int }} > 6"
+  when: ansible_distribution_major_version|int > 6
   notify: Run update-grub
 
 - meta: flush_handlers

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -49,7 +49,8 @@
   apt: upgrade=dist
   when: ansible_os_family == "Debian" and "{{ packages|length > 0 }}"
 
-- include: spark_stack.yml
+- name: Include spark_stack.yml
+  include: spark_stack.yml
   when: spark_stack and ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
 
 - name: Make sure the NTP service is stopped
@@ -129,7 +130,8 @@
   shell: echo never > /sys/kernel/mm/transparent_hugepage/enabled && echo never > /sys/kernel/mm/transparent_hugepage/defrag
   ignore_errors: true
 
-- include: unbound-dns.yml
+- name: Include unbound-dns.yml
+  include: unbound-dns.yml
   when: use_dns
 
 - name: Reconfigure resolv.conf domain

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -120,10 +120,9 @@
               state=present
               line='GRUB_CMDLINE_LINUX=$GRUB_CMDLINE_LINUX" transparent_hugepage=never"'
   when: "{{ ansible_distribution_major_version|int }} > 6"
+  notify: Run update-grub
 
-- name: Run update-grub in Grub 2
-  shell: "{{ update_grub }}"
-  when: "{{ ansible_distribution_major_version|int }} > 6"
+- meta: flush_handlers
 
 - name: Disable Transparent Huge Pages until reboot
   shell: echo never > /sys/kernel/mm/transparent_hugepage/enabled && echo never > /sys/kernel/mm/transparent_hugepage/defrag
@@ -139,6 +138,7 @@
               regexp='^domain\s+(?! {{ ansible_domain }} ).*$'
               line='domain {{ ansible_domain }}'
   when: ansible_domain != ""
+  notify: Run resolvconf
 
 - name: Reconfigure resolv.conf search
   lineinfile: dest={{ resolv_conf }}
@@ -146,10 +146,9 @@
               regexp='^search\s+(?! {{ ansible_domain }} ).*$'
               line='search {{ ansible_domain }}'
   when: ansible_domain != ""
+  notify: Run resolvconf
 
-- name: Run resolvconf
-  shell: resolvconf -u
-  when: ansible_os_family == "Debian"
+- meta: flush_handlers
 
 - name: Configure bonding
   include: bonding.yml

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -112,8 +112,7 @@
               state=present
               regexp='(^\s*kernel(\s+(?!transparent_hugepage=never)[\w=/\-\.\,]+)*)\s*$'
               line='\1 transparent_hugepage=never'
-  register: result
-  with_items: "{{ grep_result.stdout_lines }}"
+  with_items: "{{ grep_result.stdout_lines | default('') }}"
   when: ansible_os_family == "RedHat" and (ansible_distribution == "Amazon" or ansible_distribution_major_version == "6")
 
 - name: Disable Transparent Huge Pages in Grub 2

--- a/playbooks/roles/common/tasks/partitioning.yml
+++ b/playbooks/roles/common/tasks/partitioning.yml
@@ -14,4 +14,4 @@
 
 - name: Disable periodic fsck on {{ item }}
   shell: tune2fs -c0 -i0 /dev/{{ item }}1
-  when: ansible_devices[item] is defined and {{ data_disks_filesystem }}
+  when: ansible_devices[item] is defined and (data_disks_filesystem == "ext4" or data_disks_filesystem == "ext3")

--- a/playbooks/roles/common/tasks/spark_stack.yml
+++ b/playbooks/roles/common/tasks/spark_stack.yml
@@ -1,5 +1,5 @@
 - name: Custom Repo
   get_url: url=http://mirrors.dfw.cbd.rackspace.com/cbd.repo dest=/etc/yum.repos.d/
 
-- name: add default user
+- name: Add default user
   user: name={{ spark_stack_config.default_user }} groups=users

--- a/playbooks/roles/common/vars/redhat-amazon.yml
+++ b/playbooks/roles/common/vars/redhat-amazon.yml
@@ -27,7 +27,7 @@ packages:
 ntp_service: ntpd
 ntp_sync: "/usr/sbin/ntpd -gq"
 
-epel_rpm_url: "http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm"
+epel_rpm_url: "http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
 
 epel_yum: "epel-release"
 

--- a/playbooks/spark-stack.yml
+++ b/playbooks/spark-stack.yml
@@ -1,17 +1,17 @@
 ---
 - include: create_groups.yml
 
-- name: "Apply the ambari-agent role to all nodes"
+- name: Apply the ambari-agent role to all nodes
   hosts: hadoop-cluster
   become: yes
   pre_tasks:
-    - name: "Show hadoop-cluster info"
+    - name: Show hadoop-cluster info
       debug: var=hostvars[inventory_hostname]
       when: debug
   roles:
     - ambari-agent
 
-- name: "Apply the ambari-server role to ambari-node group"
+- name: Apply the ambari-server role to ambari-node group
   hosts: ambari-node
   become: yes
   roles:


### PR DESCRIPTION
- Ambari 2.2.2.0 (and removed a workaround for previous version)
- Re-arranged variables for better visibility
- Added Grafana and Spark Thrift Servers to blueprints (as recent Ambari additions)
- Added a check for existing cluster before trying to build a new one
- Added an option to wait for the cluster to be built (with a default timeout of 30 minutes)
- Some heap tweaks in the Blueprints (including Hive heap sizes)
- Added a step to clean up the temporary files from the ambari node as it can contain sensitive information
