### PR TITLE
Decreased mapreduce.task.io.sort.mb

### DIFF
--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-1-master.j2
@@ -83,7 +83,7 @@
         "mapreduce.map.memory.mb" : "8192",
         "mapreduce.reduce.java.opts" : "-Xmx6553m",
         "mapreduce.reduce.memory.mb" : "8192",
-        "mapreduce.task.io.sort.mb" : "2048",
+        "mapreduce.task.io.sort.mb" : "2047",
         "yarn.app.mapreduce.am.command-opts" : "-Xmx3276m -Dhdp.version=${hdp.version}",
         "yarn.app.mapreduce.am.resource.mb" : "4096"
       }

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-2-masters.j2
@@ -110,7 +110,7 @@
         "mapreduce.map.memory.mb" : "8192",
         "mapreduce.reduce.java.opts" : "-Xmx6553m",
         "mapreduce.reduce.memory.mb" : "8192",
-        "mapreduce.task.io.sort.mb" : "2048",
+        "mapreduce.task.io.sort.mb" : "2047",
         "yarn.app.mapreduce.am.command-opts" : "-Xmx3276m -Dhdp.version=${hdp.version}",
         "yarn.app.mapreduce.am.resource.mb" : "4096"
       }

--- a/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-multi-node-3-masters.j2
@@ -110,7 +110,7 @@
         "mapreduce.map.memory.mb" : "8192",
         "mapreduce.reduce.java.opts" : "-Xmx6553m",
         "mapreduce.reduce.memory.mb" : "8192",
-        "mapreduce.task.io.sort.mb" : "2048",
+        "mapreduce.task.io.sort.mb" : "2047",
         "yarn.app.mapreduce.am.command-opts" : "-Xmx3276m -Dhdp.version=${hdp.version}",
         "yarn.app.mapreduce.am.resource.mb" : "4096"
       }

--- a/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
+++ b/playbooks/roles/ambari-server/templates/blueprint-single-node.j2
@@ -61,7 +61,7 @@
         "mapreduce.map.memory.mb" : "4096",
         "mapreduce.reduce.java.opts" : "-Xmx6553m",
         "mapreduce.reduce.memory.mb" : "8192",
-        "mapreduce.task.io.sort.mb" : "2048",
+        "mapreduce.task.io.sort.mb" : "2047",
         "yarn.app.mapreduce.am.command-opts" : "-Xmx1638m -Dhdp.version=${hdp.version}",
         "yarn.app.mapreduce.am.resource.mb" : "2048"
       }


### PR DESCRIPTION
Decreased mapreduce.task.io.sort.mb from 2048 to 2047 to prevent hitting limit on Java array length.
