### PR TITLE
Make HDP custom_blueprint and custom_cluster_templates as variables

### DIFF
--- a/playbooks/group_vars/hortonworks
+++ b/playbooks/group_vars/hortonworks
@@ -22,6 +22,8 @@ data_disks_filesystem: xfs
 configure_firewall: false
 use_dns: false
 custom_blueprint: false
+custom_blueprint_template: blueprint-custom.j2
+custom_cluster_template: cluster-template-custom.j2
 custom_repo: false
 custom_repo_url: 'http://public-repo-1.hortonworks.com/HDP-LABS/Projects/Erie-Preview/2.5.0.0-7/centos7/'
 custom_repo_target: 'api/v1/stacks/HDP/versions/2.5/operating_systems/redhat7/repositories/HDP-2.5'

--- a/playbooks/roles/ambari-server/tasks/custom.yml
+++ b/playbooks/roles/ambari-server/tasks/custom.yml
@@ -1,6 +1,6 @@
 ---
 - name: Upload custom blueprint
-  template: src=blueprint-custom.j2 dest=/tmp/cluster_blueprint mode=0644
+  template: src={{ custom_blueprint_template }} dest=/tmp/cluster_blueprint mode=0644
 
 - name: Upload custom cluster creation template
-  template: src=cluster-template-custom.j2 dest=/tmp/cluster_template mode=0644
+  template: src={{ custom_cluster_template }} dest=/tmp/cluster_template mode=0644


### PR DESCRIPTION
This enables us to specify different custom configurations without
having to maintain that within the current code base.
