### PR TITLE
Enable support for HDP on prebuilt Azure instances

### DIFF
--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -15,5 +15,12 @@ cloud_config:
     keyname: 'hadoop-ssh-key'
     keyfile: '~/.ssh/id_rsa.pub'
 
+# If deployment is in Microsoft Azure
+# This assumes that all the vm deployments are done thru Azure tools outside
+# of this ansible setup and the bootstrap and Hortonworks setup are done using
+# ansible-hadoop.
+# NOTE: This skips a few steps in bootstrap that are not need by Azure VM's
+azure: false
+
 # set to true to show host variables
 debug: true

--- a/playbooks/group_vars/hortonworks
+++ b/playbooks/group_vars/hortonworks
@@ -2,7 +2,7 @@
 cluster_name: 'hadoop-poc'
 adminnode: 'ambari-node' 
 hdp_version: '2.5'
-ambari_version: '2.4.0.1'
+ambari_version: '2.4.1.0'
 admin_password: 'admin'
 services_password: 'AsdQwe123'
 alerts_contact: 'root@localhost.localdomain'

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -77,6 +77,7 @@
   with_items:
     - "* soft nofile 32768"
     - "* hard nofile 32768"
+  when: not azure
 
 - name: Set nproc limits
   lineinfile: dest=/etc/security/limits.d/90-nproc.conf
@@ -88,6 +89,7 @@
   with_items:
     - "* soft nproc 32768"
     - "* hard nproc 32768"
+  when: not azure
 
 - name: Set swappiness to 1
   sysctl: name=vm.swappiness value=1 state=present ignoreerrors=yes
@@ -105,7 +107,7 @@
 - name: Get number of kernels in grub.conf
   shell: grep -E "^[[:blank:]]*kernel" /boot/grub/grub.conf | grep -v transparent_hugepage; exit 0
   register: grep_result
-  when: ansible_os_family == "RedHat" and (ansible_distribution == "Amazon" or ansible_distribution_major_version == "6")
+  when: ansible_os_family == "RedHat" and (ansible_distribution == "Amazon" or ansible_distribution_major_version == "6") and not azure
   ignore_errors: true
 
 - name: Disable Transparent Huge Pages in Grub 1
@@ -115,13 +117,15 @@
               regexp='(^\s*kernel(\s+(?!transparent_hugepage=never)[\w=/\-\.\,]+)*)\s*$'
               line='\1 transparent_hugepage=never'
   with_items: "{{ grep_result.stdout_lines | default('') }}"
-  when: ansible_os_family == "RedHat" and (ansible_distribution == "Amazon" or ansible_distribution_major_version == "6")
+  when: ansible_os_family == "RedHat" and (ansible_distribution == "Amazon" or ansible_distribution_major_version == "6") and not azure
+
 
 - name: Disable Transparent Huge Pages in Grub 2
   lineinfile: dest=/etc/default/grub
               state=present
               line='GRUB_CMDLINE_LINUX=$GRUB_CMDLINE_LINUX" transparent_hugepage=never"'
   when: ansible_distribution_major_version|int > 6
+  when: not azure
   notify: Run update-grub
 
 - meta: flush_handlers
@@ -129,6 +133,7 @@
 - name: Disable Transparent Huge Pages until reboot
   shell: echo never > /sys/kernel/mm/transparent_hugepage/enabled && echo never > /sys/kernel/mm/transparent_hugepage/defrag
   ignore_errors: true
+  when: not azure
 
 - name: Reconfigure resolv.conf search
   lineinfile: dest={{ resolv_conf }}
@@ -146,6 +151,7 @@
 
 - name: Set hosts file
   template: src=hosts.j2 dest=/etc/hosts mode=0644
+  when: not azure
 
 - name: Include firewall.yml
   include: firewall.yml


### PR DESCRIPTION
Supports the bootstrap and hortonworks_static setup
on Azure.

Enables skips for dns setup, hosts file updates and grub updates
on Azure.
