### PR TITLE
Removed cluster_name from group_vars/all config and set debug to false

### DIFF
--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -1,5 +1,4 @@
 ---
-cluster_name: 'hadoopPOC'
 #valid hdp/cdh
 distro: 'hdp'
 use_dns: false
@@ -23,4 +22,4 @@ cloud_config:
 azure: false
 
 # set to true to show host variables
-debug: true
+debug: false


### PR DESCRIPTION
Removed cluster_name from group_vars/all since this is specified in group_vars/hortonworks and isn't needed during the bootstrap.  I also set Ansible debugging to default to false.