### PR TITLE
Change the Ambari admin password before other API calls and don't abort on blueprint deletion failure

### DIFF
--- a/playbooks/roles/ambari-server/tasks/main.yml
+++ b/playbooks/roles/ambari-server/tasks/main.yml
@@ -28,7 +28,7 @@
        method=PUT
        force_basic_auth=yes
        user=admin
-       password=admin
+       password={{ admin_password }}
        HEADER_X-Requested-By="ambari"
        body=" {{ hdprepo.content | b64decode }}"
        body_format=raw
@@ -47,7 +47,7 @@
        method=GET
        force_basic_auth=yes
        user=admin
-       password=admin
+       password={{ admin_password }}
        HEADER_X-Requested-By="ambari"
        status_code=200,201,202,404
        return_content=yes
@@ -58,7 +58,7 @@
        method=POST
        force_basic_auth=yes
        user=admin
-       password=admin
+       password={{ admin_password }}
        HEADER_X-Requested-By="ambari"
        body=" {{ alert_targets.content | b64decode }}"
        body_format=raw
@@ -82,9 +82,10 @@
        method=DELETE
        force_basic_auth=yes
        user=admin
-       password=admin
+       password={{ admin_password }}
        HEADER_X-Requested-By="ambari"
        status_code=200,201,202,404
+  register: delete_blueprint
   ignore_errors: true
 
 - name: Register the blueprint with the Ambari server
@@ -92,11 +93,12 @@
        method=POST
        force_basic_auth=yes
        user=admin
-       password=admin
+       password={{ admin_password }}
        HEADER_X-Requested-By="ambari"
        body=" {{ cluster_blueprint.content | b64decode }}"
        body_format=raw
        status_code=200,201,202
+  when: delete_blueprint is not failed
 
 - name: Slurp the cluster creation template
   slurp: src=/tmp/cluster_template
@@ -107,7 +109,7 @@
        method=GET
        force_basic_auth=yes
        user=admin
-       password=admin
+       password={{ admin_password }}
        HEADER_X-Requested-By="ambari"
        status_code=200,201,202,404
   register: current_cluster
@@ -117,7 +119,7 @@
        method=POST
        force_basic_auth=yes
        user=admin
-       password=admin
+       password={{ admin_password }}
        HEADER_X-Requested-By="ambari"
        body=" {{ cluster_template.content | b64decode }}"
        body_format=raw
@@ -129,7 +131,7 @@
        method=GET
        force_basic_auth=yes
        user=admin
-       password=admin
+       password={{ admin_password }}
        HEADER_Content-Type="application/json"
        HEADER_X-Requested-By="ambari"
        status_code=200,201,202
@@ -148,15 +150,3 @@
   when: wait and ((cluster_create_task.content|from_json).Requests.request_status == 'FAILED' or
          (cluster_create_task.content|from_json).Requests.request_status == 'TIMEDOUT' or
          (cluster_create_task.content|from_json).Requests.request_status == 'ABORTED')
-
-- name: Change Ambari admin user password
-  uri: url=http://{{ ansible_nodename }}:8080/api/v1/users/admin
-       method=PUT
-       force_basic_auth=yes
-       user=admin
-       password=admin
-       HEADER_X-Requested-By="ambari"
-       body=' {"Users":{ "password":"{{ admin_password }}", "old_password":"admin"}}'
-       body_format=raw
-       status_code=200,201,202
-  when: admin_password != 'admin'

--- a/playbooks/roles/ambari-server/tasks/prerequisites.yml
+++ b/playbooks/roles/ambari-server/tasks/prerequisites.yml
@@ -36,12 +36,24 @@
 - name: Waiting for ambari-server to start listening on port 8080
   wait_for: host={{ ansible_nodename }} port=8080
 
+- name: Change Ambari admin user password
+  uri: url=http://{{ ansible_nodename }}:8080/api/v1/users/admin
+       method=PUT
+       force_basic_auth=yes
+       user=admin
+       password=admin
+       HEADER_X-Requested-By="ambari"
+       body=' {"Users":{ "password":"{{ admin_password }}", "old_password":"admin"}}'
+       body_format=raw
+       status_code=200,201,202,403
+  when: admin_password != 'admin'
+
 - name: Waiting for ambari-agents to register
   uri: url=http://{{ ansible_nodename }}:8080/api/v1/hosts/{{ hostvars[item]['ansible_nodename'] | lower }}
        method=GET
        force_basic_auth=yes
        user=admin
-       password=admin
+       password={{ admin_password }}
        HEADER_X-Requested-By="ambari"
        status_code=200,201,202,404
   with_items: "{{ groups['hadoop-cluster'] }}"


### PR DESCRIPTION
Change the Ambari admin password before all other API calls and don't fail if the blueprint can't be deleted and uploaded because provisioning was already initiated